### PR TITLE
Fix dataset glob pattern

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -113,7 +113,7 @@ def get_available_loras():
 def get_datasets(path: str, ext: str):
     # include subdirectories for raw txt files to allow training from a subdirectory of txt files
     if ext == "txt":
-        return ['None'] + sorted(set([k.stem for k in list(Path(path).glob('txt')) + list(Path(path).glob('*/')) if k.stem != 'put-trainer-datasets-here']), key=natural_keys)
+        return ['None'] + sorted(set([k.stem for k in list(Path(path).glob('*.txt')) + list(Path(path).glob('*/')) if k.stem != 'put-trainer-datasets-here']), key=natural_keys)
 
     return ['None'] + sorted(set([k.stem for k in Path(path).glob(f'*.{ext}') if k.stem != 'put-trainer-datasets-here']), key=natural_keys)
 


### PR DESCRIPTION
## Summary
- fix dataset discovery bug by correctly globbing for `.txt` files

## Testing
- `python -m py_compile modules/utils.py`
- `pytest` *(fails: urllib.error.URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_6892e7b806ac832c86097b528c8cef12